### PR TITLE
Fixed compilation error

### DIFF
--- a/src/ios/MBProgressHUD.m
+++ b/src/ios/MBProgressHUD.m
@@ -598,7 +598,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
         detailsLabel.font = self.detailsLabelFont;
     } else if ([keyPath isEqualToString:@"progress"]) {
         if ([indicator respondsToSelector:@selector(setProgress:)]) {
-            [(id)indicator setProgress:progress];
+            [(id)indicator setValue:@(progress) forKey:@"progress"];
         }
         return;
     }


### PR DESCRIPTION
This fixes the compilation error
> Multiple methods named 'setProgress:' found with mismatched result, parameter type or attributes

See: https://github.com/jdg/MBProgressHUD/pull/180